### PR TITLE
ci: Test Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,6 +6,7 @@ env:
 jobs:
   python:
     strategy:
+      fail-fast: false
       matrix:
         pyver_os:
           - ver: '2.7'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,10 @@ jobs:
             os: ubuntu-latest
           - ver: '3.11'
             os: ubuntu-latest
+          - ver: '3.12'
+            os: ubuntu-latest
+          - ver: '3.13'
+            os: ubuntu-latest
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: checkout PR

--- a/src/tox_lsr/utils.py
+++ b/src/tox_lsr/utils.py
@@ -6,7 +6,17 @@
 import os
 from typing import TYPE_CHECKING, cast
 
-import pkg_resources
+try:
+    # Python 3
+    import importlib.resources
+
+    resource_filename = lambda pkg, ref: str(importlib.resources.files(pkg) / ref)
+    resource_bytes = lambda pkg, ref: (importlib.resources.files(pkg) / ref).read_bytes()
+except ImportError:
+    # Python 2
+    from pkg_resources import resource_filename
+    from pkg_resources import resource_string as resource_bytes
+
 
 if TYPE_CHECKING:
     from tox.config import Config, Parser
@@ -100,7 +110,7 @@ def get_lsr_scriptdir():
     lsr_scriptdir = os.environ.get(LSR_SCRIPTDIR_ENV)
     if not lsr_scriptdir:
         # pylint: disable=consider-using-f-string
-        lsr_script_filename = pkg_resources.resource_filename(
+        lsr_script_filename = resource_filename(
             __name__,
             "{tsdir}/{tsname}".format(
                 tsdir=TEST_SCRIPTS_SUBDIR,
@@ -118,7 +128,7 @@ def get_lsr_configdir():
     lsr_configdir = os.environ.get(LSR_CONFIGDIR_ENV)
     if not lsr_configdir:
         # pylint: disable=consider-using-f-string
-        lsr_config_filename = pkg_resources.resource_filename(
+        lsr_config_filename = resource_filename(
             __name__,
             "{cfdir}/{cfname}".format(
                 cfdir=CONFIG_FILES_SUBDIR,
@@ -134,7 +144,7 @@ def get_lsr_default():
     """Get the content of tox-default.ini."""
 
     # pylint: disable=consider-using-f-string
-    return pkg_resources.resource_string(
+    return resource_bytes(
         __name__,
         "{cfdir}/{deftox}".format(
             cfdir=CONFIG_FILES_SUBDIR,

--- a/tests/unit/test_hooks3.py
+++ b/tests/unit/test_hooks3.py
@@ -16,8 +16,6 @@ except ImportError:
 
 from copy import deepcopy
 
-import pkg_resources
-
 # I have no idea why pylint complains about this.  This works:
 # command = python -c 'import py; print(dir(py.iniconfig))'
 # bug in pylint?  anyway, just ignore it
@@ -50,6 +48,8 @@ from tox_lsr.utils import (
     LSR_ENABLE,
     SCRIPT_NAME,
     TOX_DEFAULT_INI,
+    resource_filename,
+    resource_bytes,
 )
 
 from .utils import MockConfig
@@ -62,10 +62,10 @@ class HooksTestCase(TestCase):
     def setUp(self):
         self.toxworkdir = tempfile.mkdtemp()
         patch(
-            "pkg_resources.resource_filename",
+            "tox_lsr.utils.resource_filename",
             return_value=self.toxworkdir + "/" + SCRIPT_NAME,
         ).start()
-        self.default_tox_ini_b = pkg_resources.resource_string(
+        self.default_tox_ini_b = resource_bytes(
             "tox_lsr", CONFIG_FILES_SUBDIR + "/" + TOX_DEFAULT_INI
         )
         self.default_tox_ini_raw = self.default_tox_ini_b.decode()
@@ -103,7 +103,7 @@ class HooksTestCase(TestCase):
         default_config = MockConfig(toxworkdir=self.toxworkdir)
 
         with patch(
-            "pkg_resources.resource_string",
+            "tox_lsr.utils.resource_bytes",
             return_value=self.default_tox_ini_b,
         ) as mock_rs:
             with patch("tox_lsr.hooks3.merge_config") as mock_mc:

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     tox30: tox==3.*
     py27: mock
 commands =
-    {env:SAFETY_CMD:safety} check -i 72236 -i 73456 -i 72132 -i 71064 -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 --full-report  # ignore pip, PyYAML problems
+    {env:SAFETY_CMD:safety} check -i 72236 -i 73456 -i 72132 -i 71064 -i 70612 -i 67599 -i 68477 -i 62044 -i 58755 -i 52495 -i 47833 -i 42559 -i 42218 -i 40291 -i 38765 -i 39611 -i 44492 -i 51457 -i 51499 -i 75180 --full-report  # ignore pip, PyYAML problems
     pytest --cov=tox_lsr --cov-report=term-missing tests
     {env:COVERALLS_CMD:coveralls --output={envname}-coverage.txt}
 


### PR DESCRIPTION
Shadowing https://github.com/linux-system-roles/tox-lsr/pull/178 while workflows don't start on the parent projects.